### PR TITLE
Redirect old page news to the new news overview

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,7 @@
 [build.environment]
   YARN_VERSION = "1.9.4"
   YARN_FLAGS = "--no-ignore-optional"
+
+[[redirects]]
+  from = "/news/what-s-new/*"
+  to = "/news"


### PR DESCRIPTION
Over netlify configuration redirect from /news/what-s-new/* (where all the old news articles where at) to the new news overview to fix facebook links currently leading to a 404.